### PR TITLE
Add Opacity slider to Appearance panel

### DIFF
--- a/blender_addon/ui/panels.py
+++ b/blender_addon/ui/panels.py
@@ -381,6 +381,9 @@ class PC_PT_TrackerAppearancePanel(PC_PT_PolychaseActiveTrackerBase):
         row.prop(tracker, "wireframe_width", text="Width")
 
         row = layout.row(align=True)
+        row.prop(tracker, "wireframe_color", index=3, text="Opacity", slider=True)
+
+        row = layout.row(align=True)
         split = row.split(factor=0.5, align=True)
         col = split.column(align=True)
         col.label(text="Default Pin Color")


### PR DESCRIPTION
As discussed, this adds a UI control for opacity.
<img width="365" height="262" alt="image" src="https://github.com/user-attachments/assets/0540e178-4c81-483b-9184-de496c1c2453" />

See issue #13 