### PR TITLE
Fix Pin Mode shader compile error on macOS

### DIFF
--- a/blender_addon/operators/pin_mode/rendering.py
+++ b/blender_addon/operators/pin_mode/rendering.py
@@ -122,7 +122,7 @@ def get_selection_circle_shader() -> gpu.types.GPUShader:
     void main()
     {
         const float width = 1.5f;
-        float d = abs(distance(vec2(gl_FragCoord), center) - radius);
+        float d = abs(distance(gl_FragCoord.xy), center) - radius);
         if (d < width) {
             fragColor = vec4(1.0, 1.0, 1.0, 1.0 - d/width);
         } else {


### PR DESCRIPTION
Fixes a shader compile error when entering Pin Mode on macOS/Apple Silicon.

On my system, Blender's shader compiler reports `gl_FragCoord` as a `float4`, so casting it directly with `vec2(gl_FragCoord)` fails. Using `gl_FragCoord.xy` resolves the issue.

Environment tested:

- macOS 26.3.1
- Apple M3 Max, 96 GB RAM
- Blender 5.0 and 5.1
- Polychase 0.0.13

Change made:

`vec2(gl_FragCoord)`

to:

`gl_FragCoord.xy`

This resolved the Pin Mode shader compile error on my system.